### PR TITLE
Add Groq and Cerebras as free LLM providers

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -74,6 +74,18 @@ def _generate_response(prompt: str) -> str:
                 base_url = config.app.get("deepseek_base_url")
                 if not base_url:
                     base_url = "https://api.deepseek.com"
+            elif llm_provider == "groq":
+                api_key = config.app.get("groq_api_key")
+                model_name = config.app.get("groq_model_name")
+                base_url = config.app.get("groq_base_url", "")
+                if not base_url:
+                    base_url = "https://api.groq.com/openai/v1"
+            elif llm_provider == "cerebras":
+                api_key = config.app.get("cerebras_api_key")
+                model_name = config.app.get("cerebras_model_name")
+                base_url = config.app.get("cerebras_base_url", "")
+                if not base_url:
+                    base_url = "https://api.cerebras.ai/v1"
             elif llm_provider == "ernie":
                 api_key = config.app.get("ernie_api_key")
                 secret_key = config.app.get("ernie_secret_key")

--- a/config.example.toml
+++ b/config.example.toml
@@ -30,6 +30,8 @@ pixabay_api_keys = []
 #   oneapi
 #   cloudflare
 #   ernie       (文心一言)
+#   groq        (free tier)
+#   cerebras    (free tier)
 llm_provider = "openai"
 
 ########## Pollinations AI Settings
@@ -98,6 +100,18 @@ qwen_model_name = "qwen-max"
 deepseek_api_key = ""
 deepseek_base_url = "https://api.deepseek.com"
 deepseek_model_name = "deepseek-chat"
+
+########## Groq (free tier: 14,400 requests/day)
+# Get your API key at https://console.groq.com
+groq_api_key = ""
+groq_base_url = "https://api.groq.com/openai/v1"
+groq_model_name = "llama-3.3-70b-versatile"
+
+########## Cerebras (free tier: 1M tokens/day)
+# Get your API key at https://cloud.cerebras.ai
+cerebras_api_key = ""
+cerebras_base_url = "https://api.cerebras.ai/v1"
+cerebras_model_name = "llama-3.3-70b"
 
 # Subtitle Provider, "edge" or "whisper"
 # If empty, the subtitle will not be generated

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -238,6 +238,8 @@ if not config.app.get("hide_config", False):
                 "Cloudflare",
                 "ERNIE",
                 "Pollinations",
+                "Groq",
+                "Cerebras",
             ]
             saved_llm_provider = config.app.get("llm_provider", "OpenAI").lower()
             saved_llm_provider_index = 0
@@ -391,6 +393,34 @@ if not config.app.get("hide_config", False):
                             - **API Key**: Optional - Leave empty for public access
                             - **Base Url**: Default is https://text.pollinations.ai/openai
                             - **Model Name**: Use 'openai-fast' or specify a model name
+                            """
+
+            if llm_provider == "groq":
+                if not llm_model_name:
+                    llm_model_name = "llama-3.3-70b-versatile"
+                if not llm_base_url:
+                    llm_base_url = "https://api.groq.com/openai/v1"
+                with llm_helper:
+                    tips = """
+                            ##### Groq Configuration
+                            > Free tier: 14,400 requests/day
+                            - **API Key**: [Get your key at console.groq.com](https://console.groq.com)
+                            - **Base Url**: Default is https://api.groq.com/openai/v1
+                            - **Model Name**: Default is llama-3.3-70b-versatile
+                            """
+
+            if llm_provider == "cerebras":
+                if not llm_model_name:
+                    llm_model_name = "llama-3.3-70b"
+                if not llm_base_url:
+                    llm_base_url = "https://api.cerebras.ai/v1"
+                with llm_helper:
+                    tips = """
+                            ##### Cerebras Configuration
+                            > Free tier: 1M tokens/day
+                            - **API Key**: [Get your key at cloud.cerebras.ai](https://cloud.cerebras.ai)
+                            - **Base Url**: Default is https://api.cerebras.ai/v1
+                            - **Model Name**: Default is llama-3.3-70b
                             """
 
             if tips and config.ui["language"] == "zh":


### PR DESCRIPTION
## Summary

- Add Groq and Cerebras as LLM provider options. Both offer generous free tiers and are OpenAI-compatible, so they reuse the existing OpenAI client code path.
- Groq: 14,400 requests/day free, default model `llama-3.3-70b-versatile`
- Cerebras: 1M tokens/day free, default model `llama-3.3-70b`

## Changes

- `app/services/llm.py` -- provider routing for groq and cerebras
- `config.example.toml` -- API key, base URL, and model name config entries
- `webui/Main.py` -- dropdown options and help text with free tier details

## Test plan

- [ ] Set `llm_provider = "groq"` with a valid API key, generate a video script
- [ ] Set `llm_provider = "cerebras"` with a valid API key, generate a video script
- [ ] Verify both appear in the webui dropdown with correct help text