### PR TITLE
Add retry logic for Pexels/Pixabay API calls

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 
 import requests
 from loguru import logger
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 from moviepy.video.io.VideoFileClip import VideoFileClip
 
 from app.config import config
@@ -35,6 +36,12 @@ def get_api_key(cfg_key: str):
         return api_keys[_requested_count % len(api_keys)]
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type((requests.exceptions.ConnectionError, requests.exceptions.Timeout)),
+    reraise=True,
+)
 def search_videos_pexels(
     search_term: str,
     minimum_duration: int,
@@ -99,6 +106,12 @@ def search_videos_pexels(
     return []
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type((requests.exceptions.ConnectionError, requests.exceptions.Timeout)),
+    reraise=True,
+)
 def search_videos_pixabay(
     search_term: str,
     minimum_duration: int,
@@ -155,6 +168,22 @@ def search_videos_pixabay(
     return []
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type((requests.exceptions.ConnectionError, requests.exceptions.Timeout)),
+    reraise=True,
+)
+def _download_video_content(video_url: str, headers: dict) -> bytes:
+    """Download video content with retry on transient network errors."""
+    return requests.get(
+        video_url,
+        headers=headers,
+        proxies=config.proxy,
+        timeout=(60, 240),
+    ).content
+
+
 def save_video(video_url: str, save_dir: str = "", search_term: str = "", thumbnail_url: str = "", preview_images: list = None) -> str:
     if not save_dir:
         save_dir = utils.storage_dir("cache_videos")
@@ -186,14 +215,7 @@ def save_video(video_url: str, save_dir: str = "", search_term: str = "", thumbn
 
     # if video does not exist, download it
     with open(video_path, "wb") as f:
-        f.write(
-            requests.get(
-                video_url,
-                headers=headers,
-                proxies=config.proxy,
-                timeout=(60, 240),
-            ).content
-        )
+        f.write(_download_video_content(video_url, headers))
 
     if os.path.exists(video_path) and os.path.getsize(video_path) > 0:
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ redis==5.2.0
 python-multipart==0.0.19
 pyyaml
 requests>=2.31.0
+tenacity>=8.2.0
 sentence-transformers>=2.2.0
 scikit-learn>=1.3.0
 # Image similarity dependencies


### PR DESCRIPTION
## Summary

- Add tenacity-based retry (3 attempts, exponential backoff) to `search_videos_pexels`, `search_videos_pixabay`, and video download requests
- Retries only on `ConnectionError` and `Timeout` -- non-transient errors still fail fast
- Extract `_download_video_content` helper to keep `save_video` unchanged otherwise
- Pin `tenacity>=8.2.0` in requirements.txt

## Test plan

- [ ] Verify normal Pexels/Pixabay search still works end-to-end
- [ ] Simulate a transient timeout (e.g. mock `requests.get` to raise `Timeout` once) and confirm retry succeeds
- [ ] Confirm non-retryable errors (e.g. 403) still propagate immediately