### PR TITLE
Add AI video generation using Wan2.1/2.2 models

### DIFF
--- a/app/models/schema.py
+++ b/app/models/schema.py
@@ -82,7 +82,7 @@ class VideoParams(BaseModel):
     video_clip_duration: Optional[int] = 5
     video_count: Optional[int] = 1
 
-    video_source: Optional[str] = "pexels"
+    video_source: Optional[str] = "pexels"  # pexels, pixabay, local, ai_generated
     video_materials: Optional[List[MaterialInfo]] = (
         None  # Materials used to generate the video
     )

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -8,7 +8,7 @@ from loguru import logger
 from app.config import config
 from app.models import const
 from app.models.schema import VideoConcatMode, VideoParams
-from app.services import llm, material, subtitle, video, voice
+from app.services import llm, material, subtitle, video, video_gen, voice
 from app.services import state as sm
 from app.utils import utils
 
@@ -155,7 +155,7 @@ def generate_subtitle(task_id, params, video_script, sub_maker, audio_file):
     return subtitle_path
 
 
-def get_video_materials(task_id, params, video_terms, audio_duration):
+def get_video_materials(task_id, params, video_terms, audio_duration, video_script=""):
     if params.video_source == "local":
         logger.info("\n\n## preprocess local materials")
         materials = video.preprocess_video(
@@ -168,6 +168,23 @@ def get_video_materials(task_id, params, video_terms, audio_duration):
             )
             return None
         return [material_info.url for material_info in materials]
+    elif params.video_source == "ai_generated":
+        logger.info("\n\n## generating video clips with AI")
+        generated_videos = video_gen.generate_videos(
+            task_id=task_id,
+            video_script=video_script,
+            video_terms=video_terms if video_terms else [],
+            video_aspect=params.video_aspect,
+            audio_duration=audio_duration * params.video_count,
+            max_clip_duration=params.video_clip_duration,
+        )
+        if not generated_videos:
+            sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
+            logger.error(
+                "failed to generate AI videos. Check that you have a CUDA GPU and diffusers installed."
+            )
+            return None
+        return generated_videos
     else:
         logger.info(f"\n\n## downloading videos from {params.video_source}")
         downloaded_videos = material.download_videos(
@@ -270,7 +287,7 @@ def start(task_id, params: VideoParams, stop_at: str = "video"):
 
     # 2. Generate terms
     video_terms = ""
-    if params.video_source != "local":
+    if params.video_source not in ("local", "ai_generated"):
         video_terms = generate_terms(task_id, params, video_script)
         if not video_terms:
             sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)
@@ -323,7 +340,7 @@ def start(task_id, params: VideoParams, stop_at: str = "video"):
 
     # 5. Get video materials
     downloaded_videos = get_video_materials(
-        task_id, params, video_terms, audio_duration
+        task_id, params, video_terms, audio_duration, video_script=video_script
     )
     if not downloaded_videos:
         sm.state.update_task(task_id, state=const.TASK_STATE_FAILED)

--- a/app/services/video_gen.py
+++ b/app/services/video_gen.py
@@ -1,0 +1,276 @@
+"""
+AI video generation using Wan2.1/2.2 text-to-video models via HuggingFace diffusers.
+Generates short video clips from text prompts as an alternative to stock footage.
+"""
+
+import os
+import re
+import gc
+import time
+from typing import List, Optional
+
+from loguru import logger
+
+from app.config import config
+from app.models.schema import VideoAspect
+from app.utils import utils
+
+try:
+    import torch
+    from diffusers import AutoencoderKLWan, WanPipeline
+    from diffusers.utils import export_to_video
+    DIFFUSERS_AVAILABLE = True
+except ImportError:
+    DIFFUSERS_AVAILABLE = False
+
+# Global pipeline cache
+_pipeline = None
+_pipeline_model_id = None
+
+# Model presets: (model_id, default_height, default_width, num_frames, fps)
+MODELS = {
+    "wan2.1-1.3b": {
+        "model_id": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        "heights": {"9:16": 480, "16:9": 480, "1:1": 480},
+        "widths": {"9:16": 272, "16:9": 832, "1:1": 480},
+        "num_frames": 81,
+        "fps": 15,
+        "num_inference_steps": 50,
+        "guidance_scale": 5.0,
+        "dtype": "bfloat16",
+        "vram_gb": 8,
+    },
+    "wan2.2-5b": {
+        "model_id": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        "heights": {"9:16": 704, "16:9": 704, "1:1": 704},
+        "widths": {"9:16": 400, "16:9": 1280, "1:1": 704},
+        "num_frames": 121,
+        "fps": 24,
+        "num_inference_steps": 50,
+        "guidance_scale": 5.0,
+        "dtype": "bfloat16",
+        "vram_gb": 24,
+    },
+}
+
+DEFAULT_MODEL = "wan2.1-1.3b"
+
+NEGATIVE_PROMPT = (
+    "blurry, low quality, distorted, deformed, watermark, text overlay, "
+    "low resolution, pixelated, overexposed, underexposed"
+)
+
+
+def is_available() -> bool:
+    if not DIFFUSERS_AVAILABLE:
+        return False
+    return torch.cuda.is_available()
+
+
+def get_model_config(model_name: str = "") -> dict:
+    if not model_name:
+        model_name = config.app.get("video_gen_model", DEFAULT_MODEL)
+    return MODELS.get(model_name, MODELS[DEFAULT_MODEL])
+
+
+def _load_pipeline(model_name: str = ""):
+    global _pipeline, _pipeline_model_id
+
+    model_config = get_model_config(model_name)
+    model_id = model_config["model_id"]
+
+    if _pipeline is not None and _pipeline_model_id == model_id:
+        return _pipeline
+
+    # Free existing pipeline
+    if _pipeline is not None:
+        del _pipeline
+        _pipeline = None
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    logger.info(f"Loading video generation model: {model_id}")
+    dtype = getattr(torch, model_config["dtype"])
+
+    vae = AutoencoderKLWan.from_pretrained(
+        model_id, subfolder="vae", torch_dtype=torch.float32
+    )
+    pipe = WanPipeline.from_pretrained(model_id, vae=vae, torch_dtype=dtype)
+
+    # Use CPU offload if VRAM is tight
+    try:
+        free_vram_gb = torch.cuda.mem_get_info()[0] / (1024 ** 3)
+        if free_vram_gb < model_config["vram_gb"]:
+            logger.info(f"Free VRAM ({free_vram_gb:.1f}GB) < recommended ({model_config['vram_gb']}GB), using CPU offload")
+            pipe.enable_model_cpu_offload()
+        else:
+            pipe.to("cuda")
+    except Exception:
+        pipe.enable_model_cpu_offload()
+
+    pipe.vae.enable_tiling()
+
+    _pipeline = pipe
+    _pipeline_model_id = model_id
+    logger.info(f"Video generation model loaded: {model_id}")
+    return _pipeline
+
+
+def _get_resolution(model_config: dict, aspect: VideoAspect) -> tuple:
+    aspect_key = aspect.value if hasattr(aspect, 'value') else str(aspect)
+    h = model_config["heights"].get(aspect_key, 480)
+    w = model_config["widths"].get(aspect_key, 832)
+    return h, w
+
+
+def _enhance_prompt(prompt: str) -> str:
+    """Add cinematic quality hints to the prompt for better generation."""
+    prompt = prompt.strip()
+    if not prompt:
+        return prompt
+    # Don't add hints if the prompt already has quality keywords
+    quality_words = ["cinematic", "4k", "high quality", "professional", "detailed"]
+    if any(w in prompt.lower() for w in quality_words):
+        return prompt
+    return f"{prompt}, cinematic lighting, high quality, smooth motion"
+
+
+def generate_clip(
+    prompt: str,
+    output_path: str,
+    video_aspect: VideoAspect = VideoAspect.portrait,
+    model_name: str = "",
+) -> Optional[str]:
+    """
+    Generate a single video clip from a text prompt.
+    Returns the output file path on success, None on failure.
+    """
+    if not is_available():
+        logger.error("AI video generation not available (need diffusers + CUDA GPU)")
+        return None
+
+    model_config = get_model_config(model_name)
+    height, width = _get_resolution(model_config, video_aspect)
+    enhanced_prompt = _enhance_prompt(prompt)
+
+    logger.info(f"Generating clip: '{prompt[:80]}...' ({width}x{height}, "
+                f"{model_config['num_frames']} frames)")
+
+    try:
+        pipe = _load_pipeline(model_name)
+
+        start_time = time.time()
+        output = pipe(
+            prompt=enhanced_prompt,
+            negative_prompt=NEGATIVE_PROMPT,
+            height=height,
+            width=width,
+            num_frames=model_config["num_frames"],
+            guidance_scale=model_config["guidance_scale"],
+            num_inference_steps=model_config["num_inference_steps"],
+        )
+
+        export_to_video(output.frames[0], output_path, fps=model_config["fps"])
+        elapsed = time.time() - start_time
+        logger.info(f"Clip generated in {elapsed:.0f}s: {output_path}")
+
+        # Cleanup intermediate tensors
+        del output
+        gc.collect()
+        torch.cuda.empty_cache()
+
+        return output_path
+
+    except Exception as e:
+        logger.error(f"Failed to generate clip: {e}")
+        return None
+
+
+def _split_script_to_prompts(script: str, video_terms: list = None) -> List[str]:
+    """
+    Split a video script into per-clip prompts.
+    Each sentence or short paragraph becomes a visual prompt.
+    """
+    # Split on sentence boundaries
+    sentences = re.split(r'(?<=[.!?。！？])\s*', script.strip())
+    sentences = [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
+
+    if not sentences:
+        # Fallback: use video_terms as prompts
+        if video_terms:
+            return video_terms
+        return [script[:200]]
+
+    # Merge very short sentences
+    prompts = []
+    current = ""
+    for s in sentences:
+        if len(current) + len(s) < 120:
+            current = f"{current} {s}".strip()
+        else:
+            if current:
+                prompts.append(current)
+            current = s
+    if current:
+        prompts.append(current)
+
+    return prompts if prompts else sentences
+
+
+def generate_videos(
+    task_id: str,
+    video_script: str,
+    video_terms: List[str],
+    video_aspect: VideoAspect = VideoAspect.portrait,
+    audio_duration: float = 0.0,
+    max_clip_duration: int = 5,
+) -> List[str]:
+    """
+    Generate AI video clips for a full script. Returns list of file paths.
+    This is the main entry point, matching the interface of material.download_videos.
+    """
+    if not is_available():
+        logger.error("AI video generation not available")
+        return []
+
+    model_name = config.app.get("video_gen_model", DEFAULT_MODEL)
+    model_config = get_model_config(model_name)
+    clip_duration = model_config["num_frames"] / model_config["fps"]
+
+    # Figure out how many clips we need
+    if audio_duration > 0:
+        num_clips_needed = max(1, int(audio_duration / clip_duration) + 1)
+    else:
+        num_clips_needed = 3
+
+    # Generate prompts from script
+    prompts = _split_script_to_prompts(video_script, video_terms)
+
+    # Extend prompts if we need more clips than we have prompts
+    while len(prompts) < num_clips_needed:
+        prompts.extend(prompts[:num_clips_needed - len(prompts)])
+    prompts = prompts[:num_clips_needed]
+
+    # Generate clips
+    save_dir = utils.task_dir(task_id)
+    os.makedirs(save_dir, exist_ok=True)
+
+    generated_paths = []
+    for i, prompt in enumerate(prompts):
+        output_path = os.path.join(save_dir, f"ai-clip-{i:03d}.mp4")
+        logger.info(f"Generating clip {i+1}/{len(prompts)}")
+
+        result = generate_clip(
+            prompt=prompt,
+            output_path=output_path,
+            video_aspect=video_aspect,
+            model_name=model_name,
+        )
+
+        if result and os.path.exists(result):
+            generated_paths.append(result)
+        else:
+            logger.warning(f"Clip {i+1} failed, skipping")
+
+    logger.info(f"Generated {len(generated_paths)}/{len(prompts)} video clips")
+    return generated_paths

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,5 +1,10 @@
 [app]
-video_source = "pexels" # "pexels" or "pixabay"
+video_source = "pexels" # "pexels", "pixabay", "local", or "ai_generated"
+
+# AI video generation model (only used when video_source = "ai_generated")
+# "wan2.1-1.3b" - 480p, ~8GB VRAM, runs on RTX 3060+
+# "wan2.2-5b"   - 720p, ~24GB VRAM, runs on RTX 4090
+video_gen_model = "wan2.1-1.3b"
 
 # 是否隐藏配置面板
 hide_config = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,10 +16,10 @@ pyyaml
 requests>=2.31.0
 sentence-transformers>=2.2.0
 scikit-learn>=1.3.0
+# AI video generation (optional, requires CUDA GPU)
+diffusers>=0.32.0
+accelerate>=0.30.0
 # Image similarity dependencies
 transformers>=4.21.0
 torch>=1.12.0
 pillow>=9.0.0
-# AI video generation (optional, requires CUDA GPU)
-diffusers>=0.32.0
-accelerate>=0.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ scikit-learn>=1.3.0
 transformers>=4.21.0
 torch>=1.12.0
 pillow>=9.0.0
+# AI video generation (optional, requires CUDA GPU)
+diffusers>=0.32.0
+accelerate>=0.30.0

--- a/webui/Main.py
+++ b/webui/Main.py
@@ -545,6 +545,7 @@ with middle_panel:
             (tr("Pexels"), "pexels"),
             (tr("Pixabay"), "pixabay"),
             (tr("Local file"), "local"),
+            ("AI Generated (Wan2.1/2.2)", "ai_generated"),
             (tr("TikTok"), "douyin"),
             (tr("Bilibili"), "bilibili"),
             (tr("Xiaohongshu"), "xiaohongshu"),
@@ -570,6 +571,20 @@ with middle_panel:
                 type=["mp4", "mov", "avi", "flv", "mkv", "jpg", "jpeg", "png"],
                 accept_multiple_files=True,
             )
+
+        if params.video_source == "ai_generated":
+            from app.services import video_gen
+            if not video_gen.is_available():
+                st.warning("Requires CUDA GPU + diffusers. Install: pip install diffusers transformers accelerate")
+            ai_model = st.selectbox(
+                "AI Video Model",
+                options=["wan2.1-1.3b", "wan2.2-5b"],
+                format_func=lambda x: {
+                    "wan2.1-1.3b": "Wan2.1 1.3B (8GB VRAM, 480p)",
+                    "wan2.2-5b": "Wan2.2 5B (24GB VRAM, 720p)",
+                }.get(x, x),
+            )
+            config.app["video_gen_model"] = ai_model
 
         selected_index = st.selectbox(
             tr("Video Concat Mode"),
@@ -1213,7 +1228,7 @@ if start_button:
         scroll_to_bottom()
         st.stop()
 
-    if params.video_source not in ["pexels", "pixabay", "local"]:
+    if params.video_source not in ["pexels", "pixabay", "local", "ai_generated"]:
         st.error(tr("Please Select a Valid Video Source"))
         scroll_to_bottom()
         st.stop()


### PR DESCRIPTION
## Summary

Replaces stock footage dependency with AI-generated video clips. Instead of searching Pexels/Pixabay for generic clips, this generates custom video that actually matches the script content.

Uses [Wan2.1/2.2](https://huggingface.co/Wan-AI) text-to-video models via HuggingFace diffusers. Both are Apache 2.0 licensed.

**Two model options:**

| Model | Resolution | VRAM | GPU | Gen time/clip |
|-------|-----------|------|-----|---------------|
| Wan2.1 1.3B | 480p/15fps | 8GB | RTX 3060+ | ~4 min |
| Wan2.2 5B | 720p/24fps | 24GB | RTX 4090 | ~9 min |

## How it works
1. Script gets split into sentence-level prompts
2. Each prompt generates a 5-second video clip
3. Clips are saved to disk as .mp4 files
4. Existing combine_videos pipeline handles the rest (no changes needed downstream)

Falls back gracefully — if no CUDA GPU or diffusers not installed, the UI warns the user. Existing Pexels/Pixabay sources work exactly as before.

## Changes
- New `app/services/video_gen.py` — generation service with model loading, prompt enhancement, clip generation
- Updated `app/services/task.py` — `ai_generated` branch in get_video_materials()
- Updated `webui/Main.py` — new video source option + model selector
- Updated `config.example.toml` — video_gen_model setting
- Updated `requirements.txt` — diffusers + accelerate

## Test plan
- [ ] Without GPU: select AI Generated, verify warning shows in UI
- [ ] With CUDA GPU: `pip install diffusers accelerate`
- [ ] Select "AI Generated (Wan2.1/2.2)" as video source
- [ ] Choose Wan2.1 1.3B model
- [ ] Generate a short video, verify clips are script-relevant
- [ ] Verify Pexels/Pixabay still work as before