### PR TITLE
point README clone at this fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ REQUIRED DELIVERABLES:
 
 ```bash
 # 1. Clone and setup
-git clone https://github.com/harry0703/MoneyPrinterTurbo.git
-cd MoneyPrinterTurbo
+git clone https://github.com/Asad-Ismail/MoneyPrinterTurbo-Extended.git
+cd MoneyPrinterTurbo-Extended
 conda env create -f environment.yml
 conda activate MoneyPrinterTurbo
 


### PR DESCRIPTION
## Summary
- Install clone URL was still harry0703/MoneyPrinterTurbo. Point it at this repo.

## Test plan
- [ ] Open README install block and confirm clone URL is Asad-Ismail/MoneyPrinterTurbo-Extended
- [ ] Credit links to the original project are unchanged

Closes #13

Made with [Cursor](https://cursor.com)