### PR TITLE
skip None subtitle offsets

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -2231,8 +2231,15 @@ def create_subtitle(sub_maker: SubMaker, text: str, subtitle_file: str):
     sub_line = ""
 
     try:
-        for _, (offset, sub) in enumerate(zip(sub_maker.offset, sub_maker.subs)):
-            _start_time, end_time = offset
+        offsets = sub_maker.offset or []
+        subs = sub_maker.subs or []
+        for offset, sub in zip(offsets, subs):
+            if offset is None or sub is None:
+                continue
+            try:
+                _start_time, end_time = offset
+            except (TypeError, ValueError):
+                continue
             if start_time < 0:
                 start_time = _start_time
 

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -101,6 +101,21 @@ class TestVoiceService(unittest.TestCase):
 
         self.loop.run_until_complete(_do())
 
+    def test_create_subtitle_skips_none_offsets(self):
+        sub_maker = type("SubMaker", (), {})()
+        sub_maker.offset = [None, (0, 10_000_000)]
+        sub_maker.subs = ["skip", "Hello"]
+        subtitle_file = os.path.join(temp_dir, "tts-none-offset.srt")
+        os.makedirs(temp_dir, exist_ok=True)
+        vs.create_subtitle(sub_maker=sub_maker, text="Hello", subtitle_file=subtitle_file)
+
+    def test_create_subtitle_all_none_offsets_does_not_raise(self):
+        sub_maker = type("SubMaker", (), {})()
+        sub_maker.offset = [None]
+        sub_maker.subs = ["Hello"]
+        subtitle_file = os.path.join(temp_dir, "tts-all-none-offset.srt")
+        vs.create_subtitle(sub_maker=sub_maker, text="Hello", subtitle_file=subtitle_file)
+
 if __name__ == "__main__":
     # python -m unittest test.services.test_voice.TestVoiceService.test_azure_tts_v1
     # python -m unittest test.services.test_voice.TestVoiceService.test_azure_tts_v2


### PR DESCRIPTION
## Summary
- create_subtitle crashed when an Edge TTS offset was None (cannot unpack non-iterable NoneType). Skip those chunks.

## Test plan
- [x] python -m unittest test.services.test_voice.TestVoiceService.test_create_subtitle_skips_none_offsets test.services.test_voice.TestVoiceService.test_create_subtitle_all_none_offsets_does_not_raise

Closes #12

Made with [Cursor](https://cursor.com)