### PR TITLE
retry Pexels and Pixabay HTTP on timeout

### DIFF
--- a/app/services/material.py
+++ b/app/services/material.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 import requests
 from loguru import logger
 from moviepy.video.io.VideoFileClip import VideoFileClip
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from app.config import config
 from app.models.schema import MaterialInfo, VideoAspect, VideoConcatMode
@@ -35,6 +36,16 @@ def get_api_key(cfg_key: str):
         return api_keys[_requested_count % len(api_keys)]
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type((requests.exceptions.ConnectionError, requests.exceptions.Timeout)),
+    reraise=True,
+)
+def _http_get(url, **kwargs):
+    return requests.get(url, **kwargs)
+
+
 def search_videos_pexels(
     search_term: str,
     minimum_duration: int,
@@ -54,7 +65,7 @@ def search_videos_pexels(
     logger.info(f"searching videos: {query_url}, with proxies: {config.proxy}")
 
     try:
-        r = requests.get(
+        r = _http_get(
             query_url,
             headers=headers,
             proxies=config.proxy,
@@ -120,7 +131,7 @@ def search_videos_pixabay(
     logger.info(f"searching videos: {query_url}, with proxies: {config.proxy}")
 
     try:
-        r = requests.get(
+        r = _http_get(
             query_url, proxies=config.proxy, timeout=(30, 60)
         )
         response = r.json()
@@ -187,7 +198,7 @@ def save_video(video_url: str, save_dir: str = "", search_term: str = "", thumbn
     # if video does not exist, download it
     with open(video_path, "wb") as f:
         f.write(
-            requests.get(
+            _http_get(
                 video_url,
                 headers=headers,
                 proxies=config.proxy,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ redis==5.2.0
 python-multipart==0.0.19
 pyyaml
 requests>=2.31.0
+tenacity>=8.2.0
 sentence-transformers>=2.2.0
 scikit-learn>=1.3.0
 # Image similarity dependencies

--- a/test/services/test_material.py
+++ b/test/services/test_material.py
@@ -1,0 +1,54 @@
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tenacity import wait_none
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+sys.modules.setdefault("sentence_transformers", MagicMock())
+sys.modules.setdefault("sklearn", MagicMock())
+sys.modules.setdefault("sklearn.metrics.pairwise", MagicMock())
+
+import requests
+from app.services import material
+
+
+class TestMaterialHttpRetry(unittest.TestCase):
+    def setUp(self):
+        self._wait = material._http_get.retry.wait
+        material._http_get.retry.wait = wait_none()
+
+    def tearDown(self):
+        material._http_get.retry.wait = self._wait
+
+    def test_search_pexels_retries_timeout_then_succeeds(self):
+        ok = MagicMock()
+        ok.json.return_value = {"videos": []}
+        calls = {"n": 0}
+
+        def fake_get(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise requests.exceptions.Timeout()
+            return ok
+
+        with patch.object(material, "get_api_key", return_value="k"), patch(
+            "app.services.material.requests.get", side_effect=fake_get
+        ):
+            items = material.search_videos_pexels("cats", minimum_duration=1)
+
+        self.assertEqual(items, [])
+        self.assertEqual(calls["n"], 2)
+
+    def test_http_get_reraises_after_retries(self):
+        with patch(
+            "app.services.material.requests.get",
+            side_effect=requests.exceptions.Timeout(),
+        ):
+            with self.assertRaises(requests.exceptions.Timeout):
+                material._http_get("https://example.com", timeout=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Retry requests.get on ConnectionError and Timeout (3 attempts) for Pexels search, Pixabay search, and video download.
- Retry sits on the HTTP call so the existing search try/except cannot swallow the first timeout.

## Test plan
- [x] python -m unittest test.services.test_material -v

Supersedes #10

Made with [Cursor](https://cursor.com)